### PR TITLE
Transport data though Pack files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,7 @@ jobs:
           toolchain: stable
           override: true
     - name: Create test data
-      run: cargo test
-      env:
-        CARGO_XTEST_DATA_PACK_OBJECTS: "$(pwd)/target/xtest-data"
+      run: CARGO_XTEST_DATA_PACK_OBJECTS="$(pwd)/target/xtest-data" cargo test
     - name: Pack data
       run: tar czf xtest-data.tar.gz target/xtest-data
     - uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Releases
+on: 
+  push:
+    tags:
+    - 'v*'
+jobs:
+  test-data:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust stable
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          override: true
+    - name: Create test data
+      run: cargo test
+      env:
+        CARGO_XTEST_DATA_PACK_OBJECTS: "$(pwd)/target/xtest-data"
+    - name: Pack data
+      run: tar czf xtest-data.tar.gz target/xtest-data
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: "xtest-data.tar.gz"
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtest-data"
-version = "1.0.0-beta"
+version = "1.0.0-beta.1"
 description = "Fetch auxiliary test data when testing published crates"
 license = "MIT OR Apache-2.0 OR Zlib"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtest-data"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 description = "Fetch auxiliary test data when testing published crates"
 license = "MIT OR Apache-2.0 OR Zlib"
 edition = "2018"

--- a/Readme.md
+++ b/Readme.md
@@ -55,18 +55,18 @@ instead of as a direct path.
 First, export the self-contained object-pack collection with your test runs.
 
 ```
-CARGO_XTEST_DATA_PACK_OBJECTS="$(pwd)/target/pack" cargo test
-zip xtest-data.zip -r target/pack
+CARGO_XTEST_DATA_PACK_OBJECTS="$(pwd)/target/xtest-data" cargo test
+zip xtest-data.zip -r target/xtest-data
 ```
 
 This allows utilizing the library component to provide a compelling experience
 for testing distributed packages with the test data as a separate archive. You
-can of course pack `target/pack` in any other shape or form you prefer. When
-testing a crate archive reverse these steps:
+can of course pack `target/xtest-data` in any other shape or form you prefer.
+When testing a crate archive reverse these steps:
 
 ```
 unzip xtest-data.zip
-CARGO_XTEST_DATA_PACK_OBJECTS="$(pwd)/target/pack" cargo test
+CARGO_XTEST_DATA_PACK_OBJECTS="$(pwd)/target/xtest-data" cargo test
 ```
 
 # Details

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,11 @@ documentation tests can not be ran from the published `.crate` archive alone,
 if they depend on auxiliary data files that should not be shipped to downstream
 packages and end users.
 
+There are two modes: An 'online' mode where it fetches data via shallow and
+sparse clone from a repository (online, or prepared clone) or an offline mode
+consuming git object packs as auxiliary files, which the library can also
+export as a minimal archive of test data.
+
 ## Motivation
 
 As a developer of a library, you will write some integration with the goal of
@@ -28,12 +33,7 @@ It should ensure that:
 
 ## How to apply
 
-Integrate this package as a dev-dependency into your tests. This allows
-utilizing the library component to provide a compelling experience for testing
-distributed packages without the need to distribute the test data itself. The
-main goal of this package is: if the tests run in your CI pipeline where your
-complete repository is available, then they should also work with the package
-distribution.
+Integrate this package as a dev-dependency into your tests.
 
 ```rust
 let mut path = PathBuf::from("tests/data.zip");
@@ -50,6 +50,25 @@ is that this indicates a faulty setup, not something the test should handle.
 The expectation of the library is that you access all data through this library
 instead of as a direct path.
 
+## How to use offline
+
+First, export the self-contained object-pack collection with your test runs.
+
+```
+CARGO_XTEST_DATA_PACK_OBJECTS="$(pwd)/target/pack" cargo test
+zip xtest-data.zip -r target/pack
+```
+
+This allows utilizing the library component to provide a compelling experience
+for testing distributed packages with the test data as a separate archive. You
+can of course pack `target/pack` in any other shape or form you prefer. When
+testing a crate archive reverse these steps:
+
+```
+unzip xtest-data.zip
+CARGO_XTEST_DATA_PACK_OBJECTS="$(pwd)/target/pack" cargo test
+```
+
 # Details
 
 ## Usage for crate authors
@@ -60,7 +79,7 @@ The complete interface is not much more complex than the simple version above.
 
 There is one additional detail if you want to check that your crate
 successfully passes the tests on a crate distribution. For this you can
-repurpose the `xtask` of this crate:
+repurpose the `xtask` of this crate as a binary:
 
 ```bash
 cd path/to/xtest-data
@@ -72,18 +91,19 @@ modify your workspace to include the `xtask` folder then you can always execute
 the `xtask` from your own crate.
 
 The xtask will:
-1. Run `cargo package` to create the `.crate` archive. Note that this requires
-   the sources selected for the crate to be unmodified.
-2. Decompress and unpack this archive into a temporary directory.
+1. Run `cargo package` to create the `.crate` archive and accompanying pack
+   directory. Note that this requires the sources selected for the crate to be
+   unmodified.
+2. Stop, if `test` is not selected. Otherwise, decompress and unpack this
+   archive into a temporary directory.
 3. Compile the package with `xtest-data` overrides for local development (see
-   next section). In particular: `CARGO_XTEST_DATA_REPOSITORY_ORIGIN` will
-   point to the selected path as a `file://` url; `CARGO_XTEST_DATA_TMPDIR`
-   will be set to a temporary directory create within the `target` directory;
-   `CARGO_TARGET_DIR` will also point to the target directory.
+   next section). In particular: `CARGO_XTEST_DATA_PACK_OBJECTS` will point to
+   the pack output directory; `CARGO_XTEST_DATA_TMPDIR` will be set to a
+   temporary directory create within the `target` directory; `CARGO_TARGET_DIR`
+   will also point to the target directory.
 
 This keeps the `rustc` cached data around while otherwise simulating a fresh
 distribution compilation.
-
 
 ## Customization points for packagers
 
@@ -97,13 +117,20 @@ In a non-source setting (i.e. when running from a downloaded crate) the
 
 * `CARGO_XTEST_DATA_TMPDIR` (fallback: `TMPDIR`) is required to be set when any
   of the tests are _NOT_ integration tests.
+* `CARGO_XTEST_DATA_PACK_OBJECTS`: A directory for git pack objects (see `man
+  git pack-objects`). Pack files are written to this directory when running
+  tests from source, and read from this directory when running tests from a
+  `.crate` archive. These are the same objects that would be fetched when doing
+  a shallow  and sparse clone from the source repository.
 * `CARGO_XTEST_DATA_REPOSITORY_ORIGIN`: Can be set to override the Git url that
-  is used as the source repository. Otherwise the repository from the package
-  data is used.
-* `CARGO_XTEST_DATA_FETCH`: If set to `1`, `yes`, `true` then it will try to
-  make a network connection, fetch data from the source repository. If _not_
-  set then it will print a plan of what it intended to do and which files it
-  would request (as git pathspecs) from which commit, and then panic.
+  is used as the fallback source repository. Only used when no pack object
+  directory is provided. By default, set to the repository from the package
+  manifest.
+* `CARGO_XTEST_DATA_FETCH`: Only used when no pack object directory is
+  provided. If set to `1`, `yes`, `true` then it will try to make a network
+  connection, fetch data from the source repository. If _not_ set then it will
+  print a plan of what it intended to do and which files it would request (as
+  git pathspecs) from which commit, and then panic.
 
 ## How it works
 
@@ -126,6 +153,8 @@ to download and checkout requested files to the relative location.
   small amount of dependencies. (Any patches to minimize this further are
   welcome. We might add a toggle to disable locks and its dependencies if
   non-parallel test execution is good enough?)
+* A full offline mode with minimal auxiliary source archives is provided.
+  Building the crate without executing tests does not require any test data.
 * The `xtask` tool can be used for local development and CI (we use it in our
   own pipeline for example). It's not strongly linked to the implementation,
   just the public interface, so it is possible to replace it with your own

--- a/src/git.rs
+++ b/src/git.rs
@@ -235,6 +235,10 @@ impl CrateDir {
         } = paths.collect();
         let sparse = self.sparse_rev_list(git, &simple_filter);
 
+        if !complex_paths.is_empty() {
+            inconclusive(&mut "Sorry, paths too complex to pack reliably");
+        }
+
         let mut cmd = self.exec(git);
         cmd.args(["pack-objects"]);
         cmd.arg(Path::new(&pack_name).join("xtest-data"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,8 @@ pub struct Setup<'paths> {
     source: Source,
     /// The resources that we store.
     resources: Resources<'paths>,
+    /// A git pack archive with files.
+    pack_objects: Option<OsString>,
 }
 
 /// The options determined from the compile time environment of the crate that called us.
@@ -223,7 +225,8 @@ pub fn _setup(options: EnvOptions) -> Setup<'static> {
 
     let vcs_info_path = Path::new(manifest).join(".cargo_vcs_info.json");
 
-    let source = if vcs_info_path.exists() {
+    let (source, pack_objects);
+    if vcs_info_path.exists() {
         // Allow the override.
         trait GetKey {
             fn get_key(&self, key: &str) -> Option<&Self>;
@@ -268,15 +271,17 @@ pub fn _setup(options: EnvOptions) -> Setup<'static> {
             .expect("This setup must only be called in an integration test or benchmark, or with an explicit TMPDIR")
             .into_owned();
 
-        Source::VcsFromManifest {
+        pack_objects = None;
+        source = Source::VcsFromManifest {
             commit_id,
             git,
             datadir,
-        }
+        };
     } else {
         // Check that we can recognize tracked files.
         let git = git::Git::new().unwrap_or_else(|mut err| inconclusive(&mut err));
-        Source::Local(git)
+        source = Source::Local(git);
+        pack_objects = std::env::var_os("CARGO_XTEST_DATA_PACK_OBJECTS");
     };
 
     // And finally this must be valid.
@@ -289,6 +294,7 @@ pub fn _setup(options: EnvOptions) -> Setup<'static> {
         manifest,
         source,
         resources: Resources::default(),
+        pack_objects,
     }
 }
 
@@ -367,10 +373,16 @@ impl<'lt> Setup<'lt> {
                 let dir = git::CrateDir::new(self.manifest, &git);
                 let datapath = Path::new(self.manifest);
                 dir.tracked(&git, &mut self.resources.path_specs());
+
+                if let Some(pack_objects) = self.pack_objects {
+                    dir.pack_objects(&git, &mut self.resources.path_specs(), pack_objects);
+                }
+
                 map = vec![];
                 self.resources.relative_files.iter().for_each(|path| {
                     map.push(datapath.join(path.as_path()));
                 });
+
                 self.resources
                     .unmanaged
                     .into_iter()
@@ -505,6 +517,7 @@ fn unique_dir(base: &Path, prefix: &str) -> Result<PathBuf, std::io::Error> {
 }
 
 #[cold]
+#[track_caller]
 fn inconclusive(err: &mut dyn std::fmt::Display) -> ! {
     eprintln!("xtest-data failed to setup.");
     eprintln!("Information: {}", err);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), LocatedError> {
     Command::new(CARGO)
         .current_dir(&extracted)
         .args(["test", "--no-fail-fast", "--release", "--", "--nocapture"])
-        .env("CARGO_TARGET_DIR",  repo.join("target"))
+        .env("CARGO_TARGET_DIR", repo.join("target"))
         .env("CARGO_XTEST_DATA_TMPDIR", &tmp)
         .env("CARGO_XTEST_DATA_PACK_OBJECTS", &packdir)
         .success()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,6 +16,18 @@ fn main() -> Result<(), LocatedError> {
     let target = Target::from_current_dir()?;
     let filename = target.expected_crate_name();
 
+    let packdir = repo
+        .canonicalize()
+        .map_err(anchor_error())?
+        .join("target")
+        .join("pack");
+
+    Command::new(CARGO)
+        .args(["test"])
+        .env("CARGO_XTEST_DATA_PACK_OBJECTS", &packdir)
+        .success()
+        .map_err(anchor_error())?;
+
     Command::new(CARGO)
         .args(["package", "--no-verify"])
         .success()
@@ -61,13 +73,9 @@ fn main() -> Result<(), LocatedError> {
     Command::new(CARGO)
         .current_dir(&extracted)
         .args(["test", "--no-fail-fast", "--release", "--", "--nocapture"])
-        .env("CARGO_TARGET_DIR", repo.join("target"))
+        .env("CARGO_TARGET_DIR",  repo.join("target"))
         .env("CARGO_XTEST_DATA_TMPDIR", &tmp)
-        .env("CARGO_XTEST_DATA_FETCH", "yes")
-        .env(
-            "CARGO_XTEST_DATA_REPOSITORY_ORIGIN",
-            format!("file://{}", repo.display()),
-        )
+        .env("CARGO_XTEST_DATA_PACK_OBJECTS", &packdir)
         .success()
         .map_err(anchor_error())?;
 
@@ -75,6 +83,7 @@ fn main() -> Result<(), LocatedError> {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct LocatedError {
     location: &'static std::panic::Location<'static>,
     inner: io::Error,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), LocatedError> {
         .canonicalize()
         .map_err(anchor_error())?
         .join("target")
-        .join("pack");
+        .join("xtest-data");
 
     Command::new(CARGO)
         .args(["test"])


### PR DESCRIPTION
An alternative to git fetch, create a full archive of all relevant data.

See release [v1.0.0-beta.1](https://github.com/HeroicKatora/xtest-data/releases/tag/v1.0.0-beta.1) where you can download such an artifact: xtest-data.tar.gz 1.62 KB

