### PR TITLE
Xtask metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,22 @@ version = "0.6.1"
 default-features = false
 features = ["std", "tls", "wyrand"]
 
+# See `Readme.md` on meaning.
+#
+# This pre-configured table ensures that other tools can read the information
+# to fetch the archive for us. For example, a packaging-tool such as Debian's
+# standard Rust tooling may automatically generate test deps and archives.
+#
+# Note: the `xtask` will be parsing this, *NOT* the xtest-data crate itself.
+# We merely define some standard options.
+[package.metadata.xtest-data]
+# Method for archiving the pack data.
+pack-archive = "tar:gz"
+# URL template from which to fetch packed file during testing.
+pack-artifact = "{repository}/releases/xtest-data-v{version}/artifacts/xtest-data.tar.gz"
+# Relative path to export data to, and expect pack objects in.
+pack-objects = "target/xtest-data-pack"
+
+
 [workspace]
 members = [".", "xtask"]

--- a/Readme.md
+++ b/Readme.md
@@ -131,6 +131,13 @@ In a non-source setting (i.e. when running from a downloaded crate) the
   connection, fetch data from the source repository. If _not_ set then it will
   print a plan of what it intended to do and which files it would request (as
   git pathspecs) from which commit, and then panic.
+* `CARGO_XTEST_VCS_INFO`: Path to a file with version control information as
+  json, equivalent in structure to cargo's generated VCS information. This will
+  force xtest into VCS mode, where resources are replaced with data from the
+  pack object(s). Can be used to either force crates to supply internal vcs
+  information or to supplement such information. For example, packages
+  generated with `cargo package --allow-dirty` will not include such a file,
+  and this can be used to override with a forced selection.
 
 ## How it works
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -420,8 +420,7 @@ impl ShallowBareRepository {
                 .unwrap_or_else(|mut err| inconclusive(&mut err));
             if !exit.status.success() {
                 eprintln!("{}", String::from_utf8_lossy(&exit.stderr));
-                // FIXME: re-enable?
-                // inconclusive(&mut "Git operation was not successful");
+                inconclusive(&mut "Git operation was not successful");
             }
         }
     }
@@ -461,7 +460,7 @@ impl ShallowBareRepository {
             let mut cmd = self.exec(git);
             cmd.arg("--work-tree");
             cmd.arg(worktree);
-            cmd.args(["sparse-checkout", "set", "--stdin"]);
+            cmd.args(["sparse-checkout", "--no-cone", "set", "--stdin"]);
             cmd.stdin(Stdio::piped());
             let mut running = cmd.spawn()?;
             let stdin = running.stdin.as_mut().expect("Spawned with stdio-piped");
@@ -502,8 +501,7 @@ impl ShallowBareRepository {
 
         if !exit.status.success() {
             eprintln!("{}", String::from_utf8_lossy(&exit.stderr));
-            // FIXME: re-enable
-            // inconclusive(&mut "Git operation was not successful");
+            inconclusive(&mut "Git operation was not successful");
         }
 
         self.checkout_fallback_slow(git, worktree, head, &mut complex_paths.into_iter());
@@ -538,8 +536,7 @@ impl ShallowBareRepository {
             .unwrap_or_else(|mut err| inconclusive(&mut err));
         if !exit.status.success() {
             eprintln!("{}", String::from_utf8_lossy(&exit.stderr));
-            // FIXME: re-enable?
-            // inconclusive(&mut "Git operation was not successful");
+            inconclusive(&mut "Git operation was not successful");
         }
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -420,7 +420,8 @@ impl ShallowBareRepository {
                 .unwrap_or_else(|mut err| inconclusive(&mut err));
             if !exit.status.success() {
                 eprintln!("{}", String::from_utf8_lossy(&exit.stderr));
-                inconclusive(&mut "Git operation was not successful");
+                // FIXME: re-enable?
+                // inconclusive(&mut "Git operation was not successful");
             }
         }
     }
@@ -501,7 +502,8 @@ impl ShallowBareRepository {
 
         if !exit.status.success() {
             eprintln!("{}", String::from_utf8_lossy(&exit.stderr));
-            inconclusive(&mut "Git operation was not successful");
+            // FIXME: re-enable
+            // inconclusive(&mut "Git operation was not successful");
         }
 
         self.checkout_fallback_slow(git, worktree, head, &mut complex_paths.into_iter());
@@ -536,7 +538,8 @@ impl ShallowBareRepository {
             .unwrap_or_else(|mut err| inconclusive(&mut err));
         if !exit.status.success() {
             eprintln!("{}", String::from_utf8_lossy(&exit.stderr));
-            inconclusive(&mut "Git operation was not successful");
+            // FIXME: re-enable?
+            // inconclusive(&mut "Git operation was not successful");
         }
     }
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,5 +5,8 @@ edition = "2018"
 publish = false
 
 [dependencies]
+ureq = "0.7"
+serde = { version = "1", features = ["derive"] }
 tempdir = "0.3.7"
+tinytemplate = "1"
 toml = "0.5"


### PR DESCRIPTION
Introduce some package metadata to specify the pack archive location and other data.

The goal is to add information to `Cargo.toml` that `cargo` but also other build tools can consume, to split the steps of downloading, preparing, running in any fragment they want. The `xtask` then becomes a simple reference implementation for such a tool (with commands for running on a `.crate` archive to be provided in a later PR).